### PR TITLE
Feature "asm" has been stable since 1.59.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(asm)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
The full error (this PR is the fix for it):
```log
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> ./src/main.rs:1:12
  |
1 | #![feature(asm)]
  |            ^^^

warning: the feature `asm` has been stable since 1.59.0 and no longer requires an attribute to enable
 --> ./src/main.rs:1:12
  |
1 | #![feature(asm)]
  |            ^^^
  |
  = note: `#[warn(stable_features)]` on by default
```
That's it. The other error I got had to do with glibc; I'm running a fork of Bionic xUbuntu (GalliumOS, if you're curious). For correctness's sake, if nothing else, this should no longer be in the proof-of-concept.